### PR TITLE
feat: Increase test coverage

### DIFF
--- a/tests/test_async_manager.py
+++ b/tests/test_async_manager.py
@@ -1,0 +1,320 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from authtuna.manager.asynchronous import UserManager, AuthTunaAsync
+from authtuna.core.exceptions import UserAlreadyExistsError, UserNotFoundError, InvalidCredentialsError, OperationForbiddenError, InvalidTokenError
+from authtuna.core.database import User
+from authtuna.core.config import settings
+
+@pytest.fixture
+def user_manager():
+    """Provides a UserManager instance with a correctly mocked DB manager."""
+    db_manager = MagicMock()
+
+    session_mock = AsyncMock()
+
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = session_mock
+
+    db_manager.get_db.return_value = context_manager
+    db_manager.log_audit_event = AsyncMock()
+
+    return UserManager(db_manager), session_mock
+
+@pytest.mark.asyncio
+async def test_user_manager_create_success(user_manager):
+    """
+    Tests successful user creation.
+    """
+    manager, session_mock = user_manager
+
+    mock_result = MagicMock()
+    mock_result.unique.return_value.scalar_one_or_none.return_value = None
+    session_mock.execute = AsyncMock(return_value=mock_result)
+
+    with patch('authtuna.manager.asynchronous.is_email_valid', new=AsyncMock()), \
+         patch('authtuna.core.database.User.set_password', new=AsyncMock()):
+
+        user = await manager.create("test@example.com", "testuser", "password")
+
+        assert user.email == "test@example.com"
+        assert user.username == "testuser"
+        session_mock.add.assert_called_once()
+        manager._db_manager.log_audit_event.assert_called_once()
+        session_mock.commit.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_user_manager_create_user_exists(user_manager):
+    """
+    Tests that creating a user who already exists raises UserAlreadyExistsError.
+    """
+    manager, session_mock = user_manager
+
+    mock_result = MagicMock()
+    mock_result.unique.return_value.scalar_one_or_none.return_value = MagicMock()
+    session_mock.execute = AsyncMock(return_value=mock_result)
+
+    with patch('authtuna.manager.asynchronous.is_email_valid', new=AsyncMock()):
+        with pytest.raises(UserAlreadyExistsError):
+            await manager.create("test@example.com", "testuser", "password")
+
+@pytest.mark.asyncio
+async def test_user_manager_delete_success(user_manager):
+    """
+    Tests successful user deletion.
+    """
+    manager, session_mock = user_manager
+    mock_user = MagicMock()
+    mock_user.id = "test_user_id"
+    mock_user.email = "test@example.com"
+
+    table_mock = MagicMock()
+
+    id_col = MagicMock()
+    id_col.name = 'id'
+    email_col = MagicMock()
+    email_col.name = 'email'
+
+    table_mock.columns = [id_col, email_col]
+    mock_user.__table__ = table_mock
+
+    session_mock.get.return_value = mock_user
+
+    await manager.delete("test_user_id")
+
+    session_mock.add.assert_called_once()
+    session_mock.delete.assert_called_once_with(mock_user)
+    manager._db_manager.log_audit_event.assert_called_once()
+    session_mock.commit.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_user_manager_delete_not_found(user_manager):
+    """
+    Tests that deleting a non-existent user raises UserNotFoundError.
+    """
+    manager, session_mock = user_manager
+    session_mock.get.return_value = None
+
+    with pytest.raises(UserNotFoundError):
+        await manager.delete("test_user_id")
+
+@pytest.mark.asyncio
+async def test_signup_success():
+    """
+    Tests successful user signup.
+    """
+    db_manager = AsyncMock()
+    auth_tuna = AuthTunaAsync(db_manager)
+
+    mock_user = MagicMock(spec=User)
+    mock_user.id = "new_user_id"
+
+    with patch.object(auth_tuna.users, 'create', new=AsyncMock(return_value=mock_user)) as mock_create, \
+         patch.object(auth_tuna.roles, 'assign_to_user', new=AsyncMock()) as mock_assign, \
+         patch.object(auth_tuna.tokens, 'create', new=AsyncMock()) as mock_token_create:
+
+        user, token = await auth_tuna.signup("testuser", "test@example.com", "password", "127.0.0.1")
+
+        mock_create.assert_called_once()
+        mock_assign.assert_called_once_with("new_user_id", "User", assigner_id="system", scope="global")
+        if settings.EMAIL_ENABLED:
+            mock_token_create.assert_called_once()
+        else:
+            mock_token_create.assert_not_called()
+        assert user == mock_user
+
+@pytest.mark.asyncio
+async def test_login_success(user_manager):
+    """
+    Tests successful user login.
+    """
+    manager, session_mock = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_user = MagicMock(spec=User)
+    mock_user.is_active = True
+    mock_user.mfa_enabled = False
+
+    async def check_password_true(*args, **kwargs):
+        return True
+
+    mock_user.check_password = check_password_true
+
+    mock_result = MagicMock()
+    mock_result.unique.return_value.scalar_one_or_none.return_value = mock_user
+    session_mock.execute = AsyncMock(return_value=mock_result)
+
+    with patch('authtuna.manager.asynchronous.select'), \
+         patch.object(auth_tuna.sessions, 'create', new=AsyncMock(return_value=MagicMock())) as mock_session_create:
+
+        user, session = await auth_tuna.login("testuser", "password", "127.0.0.1", "test-region", "test-device")
+        assert user == mock_user
+        mock_session_create.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_login_invalid_credentials(user_manager):
+    """
+    Tests login with invalid credentials.
+    """
+    manager, session_mock = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_result = MagicMock()
+    mock_result.unique.return_value.scalar_one_or_none.return_value = None
+    session_mock.execute = AsyncMock(return_value=mock_result)
+
+    with patch('authtuna.manager.asynchronous.select'):
+        with pytest.raises(InvalidCredentialsError):
+            await auth_tuna.login("testuser", "password", "127.0.0.1", "test-region", "test-device")
+
+@pytest.mark.asyncio
+async def test_user_manager_suspend_and_unsuspend_user(user_manager):
+    """
+    Tests suspending and unsuspending a user.
+    """
+    manager, session_mock = user_manager
+    mock_user = MagicMock(spec=User)
+    mock_user.is_active = True
+    session_mock.get.return_value = mock_user
+
+    suspended_user = await manager.suspend_user("test_user_id", "admin_id")
+    assert not suspended_user.is_active
+    manager._db_manager.log_audit_event.assert_called_with("test_user_id", "USER_SUSPENDED", "system", {"by": "admin_id", "reason": "No reason provided."}, db=session_mock)
+
+    unsuspended_user = await manager.unsuspend_user("test_user_id", "admin_id")
+    assert unsuspended_user.is_active
+    manager._db_manager.log_audit_event.assert_called_with("test_user_id", "USER_UNSUSPENDED", "system", {"by": "admin_id", "reason": "No reason provided."}, db=session_mock)
+
+@pytest.mark.asyncio
+async def test_login_suspended_user(user_manager):
+    """
+    Tests that a suspended user cannot log in.
+    """
+    manager, session_mock = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_user = MagicMock(spec=User)
+    mock_user.is_active = False # User is suspended
+
+    async def check_password_true(*args, **kwargs):
+        return True
+
+    mock_user.check_password = check_password_true
+
+    mock_result = MagicMock()
+    mock_result.unique.return_value.scalar_one_or_none.return_value = mock_user
+    session_mock.execute = AsyncMock(return_value=mock_result)
+
+    with patch('authtuna.manager.asynchronous.select'):
+        with pytest.raises(OperationForbiddenError):
+            await auth_tuna.login("testuser", "password", "127.0.0.1", "test-region", "test-device")
+
+@pytest.mark.asyncio
+async def test_change_password_success(user_manager):
+    """
+    Tests successful password change.
+    """
+    manager, session_mock = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_user = MagicMock(spec=User)
+    mock_user.id = "user1"
+
+    async def check_password(password, *args, **kwargs):
+        return password == "old_password"
+
+    mock_user.check_password = check_password
+    mock_user.set_password = AsyncMock()
+
+    session_mock.get.return_value = mock_user
+
+    with patch.object(auth_tuna.sessions, 'terminate_all_for_user', new=AsyncMock()) as mock_terminate:
+        await auth_tuna.change_password(mock_user, "old_password", "new_password", "127.0.0.1", "session1")
+
+        mock_user.set_password.assert_called_once_with("new_password", "127.0.0.1", db_manager_custom=auth_tuna.db_manager, db=session_mock)
+        mock_terminate.assert_called_once_with("user1", "127.0.0.1", except_session_id="session1", db=session_mock)
+
+@pytest.mark.asyncio
+async def test_change_password_invalid_current_password(user_manager):
+    """
+    Tests that changing password fails with an invalid current password.
+    """
+    manager, session_mock = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_user = MagicMock(spec=User)
+
+    async def check_password(password, *args, **kwargs):
+        return password == "old_password"
+
+    mock_user.check_password = check_password
+    session_mock.get.return_value = mock_user
+
+    with pytest.raises(InvalidCredentialsError):
+        await auth_tuna.change_password(mock_user, "wrong_password", "new_password", "127.0.0.1", "session1")
+
+@pytest.mark.asyncio
+async def test_reset_password_success(user_manager):
+    manager, _ = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_user = MagicMock(spec=User)
+    mock_user.set_password = AsyncMock()
+
+    with patch.object(auth_tuna.tokens, 'validate', new=AsyncMock(return_value=mock_user)) as mock_validate:
+        user = await auth_tuna.reset_password("valid_token", "new_password", "127.0.0.1")
+
+        mock_validate.assert_called_once()
+        mock_user.set_password.assert_called_once()
+        assert user == mock_user
+
+@pytest.mark.asyncio
+async def test_verify_email_success(user_manager):
+    manager, _ = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_user = MagicMock(spec=User)
+    mock_user.email_verified = False
+
+    with patch.object(auth_tuna.tokens, 'validate', new=AsyncMock(return_value=mock_user)) as mock_validate:
+        user = await auth_tuna.verify_email("valid_token", "127.0.0.1")
+
+        mock_validate.assert_called_once()
+        assert user.email_verified is True
+
+@pytest.mark.asyncio
+async def test_request_password_reset_success(user_manager):
+    manager, session_mock = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_result = MagicMock()
+    mock_result.scalar.return_value = 0
+    session_mock.execute = AsyncMock(return_value=mock_result)
+
+    with patch.object(auth_tuna.users, 'get_by_email', new=AsyncMock(return_value=MagicMock())) as mock_get_by_email, \
+         patch.object(auth_tuna.tokens, 'create', new=AsyncMock()) as mock_create:
+
+        await auth_tuna.request_password_reset("test@example.com")
+
+        mock_get_by_email.assert_called_once()
+        mock_create.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_validate_mfa_login_invalid_code(user_manager):
+    manager, session_mock = user_manager
+    auth_tuna = AuthTunaAsync(manager._db_manager)
+
+    mock_user = MagicMock(spec=User)
+    mfa_method = MagicMock(method_type='totp', secret='secret')
+    mock_user_with_mfa = MagicMock(spec=User)
+    mock_user_with_mfa.mfa_methods = [mfa_method]
+
+    mock_result = MagicMock()
+    mock_result.unique.return_value.scalar_one_or_none.return_value = mock_user_with_mfa
+    session_mock.execute = AsyncMock(return_value=mock_result)
+
+    with patch.object(auth_tuna.tokens, 'validate', new=AsyncMock(return_value=mock_user)), \
+         patch('pyotp.TOTP.verify', return_value=False), \
+         patch.object(auth_tuna.mfa, 'verify_recovery_code', new=AsyncMock(return_value=False)):
+
+        with pytest.raises(InvalidTokenError):
+            await auth_tuna.validate_mfa_login("mfa_token", "wrong_code", "127.0.0.1", {})

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -1,0 +1,373 @@
+import pytest
+import time
+from unittest.mock import MagicMock, patch
+from authtuna.core.passkeys import PasskeysCore
+from authtuna.core.encryption import encryption_utils
+from authtuna.core.config import settings
+import json
+import cbor2
+import hashlib
+import os
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa, padding
+from cryptography.hazmat.primitives import hashes
+
+@pytest.fixture
+def passkeys_core():
+    """Provides a PasskeysCore instance for testing."""
+    return PasskeysCore()
+
+def test_generate_registration_options(passkeys_core):
+    """
+    Tests the generation of registration options to ensure they are well-formed.
+    """
+    user_id = "test_user_id"
+    username = "test_user"
+    existing_credentials = []
+
+    options, session_challenge = passkeys_core.generate_registration_options(
+        user_id, username, existing_credentials
+    )
+
+    # Validate the structure of the options dictionary
+    assert "rp" in options
+    assert "user" in options
+    assert "challenge" in options
+    assert "pubKeyCredParams" in options
+    assert "authenticatorSelection" in options
+
+    # Validate user information
+    assert options["user"]["name"] == username
+    assert options["user"]["displayName"] == username
+
+    # Validate the session challenge
+    assert "challenge" in session_challenge
+    assert "timestamp" in session_challenge
+    assert options["challenge"] == session_challenge["challenge"]
+
+def test_generate_authentication_options(passkeys_core):
+    """
+    Tests the generation of authentication options to ensure they are well-formed.
+    """
+    options, session_challenge = passkeys_core.generate_authentication_options(
+        existing_credentials=[]
+    )
+
+    # Validate the structure of the options dictionary
+    assert "challenge" in options
+    assert "allowCredentials" in options
+    assert "userVerification" in options
+    assert options["userVerification"] == "required"
+
+    # Validate the session challenge
+    assert "challenge" in session_challenge
+    assert "timestamp" in session_challenge
+    assert options["challenge"] == session_challenge["challenge"]
+
+def test_generate_auth_options_with_credentials(passkeys_core):
+    """
+    Tests generation of authentication options with existing credentials.
+    """
+    class MockCredential:
+        def __init__(self, cred_id):
+            self.id = cred_id
+
+    existing_credentials = [MockCredential(b'cred1'), MockCredential(b'cred2')]
+
+    options, _ = passkeys_core.generate_authentication_options(existing_credentials)
+
+    assert len(options["allowCredentials"]) == 2
+    assert options["allowCredentials"][0]["type"] == "public-key"
+    assert "id" in options["allowCredentials"][0]
+
+@pytest.fixture
+def mock_session_challenge():
+    return {
+        "challenge": encryption_utils.base64url_encode(b"test_challenge"),
+        "timestamp": time.time(),
+    }
+
+def test_verify_registration_expired_challenge(passkeys_core, mock_session_challenge, monkeypatch):
+    """
+    Tests that registration verification fails if the challenge has expired.
+    """
+    monkeypatch.setattr(time, "time", lambda: mock_session_challenge["timestamp"] + 300)
+    with pytest.raises(ValueError, match="Challenge expired"):
+        passkeys_core.verify_registration({}, mock_session_challenge)
+
+def test_verify_registration_challenge_mismatch(passkeys_core, mock_session_challenge):
+    """
+    Tests that registration verification fails if the client data challenge does not match.
+    """
+    client_data = {
+        "type": "webauthn.create",
+        "challenge": encryption_utils.base64url_encode(b"wrong_challenge"),
+        "origin": f"https://{settings.WEBAUTHN_RP_ID}",
+    }
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(json.dumps(client_data).encode()),
+        }
+    }
+    with pytest.raises(ValueError, match="Challenge mismatch"):
+        passkeys_core.verify_registration(response, mock_session_challenge)
+
+def test_verify_registration_invalid_type(passkeys_core, mock_session_challenge):
+    """
+    Tests that verification fails if the client data type is not 'webauthn.create'.
+    """
+    client_data = {
+        "type": "webauthn.get",
+        "challenge": mock_session_challenge["challenge"],
+        "origin": f"https://{settings.WEBAUTHN_RP_ID}",
+    }
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(json.dumps(client_data).encode()),
+        }
+    }
+    with pytest.raises(ValueError, match="Invalid client data type"):
+        passkeys_core.verify_registration(response, mock_session_challenge)
+
+def test_verify_registration_invalid_origin(passkeys_core, mock_session_challenge):
+    """
+    Tests that verification fails if the origin does not match the RP ID.
+    """
+    client_data = {
+        "type": "webauthn.create",
+        "challenge": mock_session_challenge["challenge"],
+        "origin": "https://evil.com",
+    }
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(json.dumps(client_data).encode()),
+        }
+    }
+    with pytest.raises(ValueError, match="not valid for RP ID"):
+        passkeys_core.verify_registration(response, mock_session_challenge)
+
+def _create_mock_attestation_object(correct_rp_id=True, correct_flags=True, key_type='ec'):
+    """Helper function to create a mock attestation object for testing."""
+    if key_type == 'ec':
+        private_key = ec.generate_private_key(ec.SECP256R1())
+        public_key = private_key.public_key()
+        public_numbers = public_key.public_numbers()
+        cose_key = {
+            1: 2, 3: -7, -1: 1,
+            -2: public_numbers.x.to_bytes(32, 'big'),
+            -3: public_numbers.y.to_bytes(32, 'big'),
+        }
+    elif key_type == 'rsa':
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        public_key = private_key.public_key()
+        public_numbers = public_key.public_numbers()
+        cose_key = {
+            1: 3, 3: -257,
+            -1: public_numbers.n.to_bytes((public_numbers.n.bit_length() + 7) // 8, 'big'),
+            -2: public_numbers.e.to_bytes((public_numbers.e.bit_length() + 7) // 8, 'big'),
+        }
+
+    rp_id = settings.WEBAUTHN_RP_ID if correct_rp_id else "evil.com"
+    rp_id_hash = hashlib.sha256(rp_id.encode("utf-8")).digest()
+
+    flags = 0b01000001 if correct_flags else 0b00000000 # User Present and Attested Credential Data
+    sign_count = 0
+    aaguid = os.urandom(16)
+    credential_id = os.urandom(16)
+    credential_id_len = len(credential_id).to_bytes(2, 'big')
+
+    auth_data = (
+        rp_id_hash +
+        flags.to_bytes(1, 'big') +
+        sign_count.to_bytes(4, 'big') +
+        aaguid +
+        credential_id_len +
+        credential_id +
+        cbor2.dumps(cose_key)
+    )
+
+    attestation_object = {
+        "fmt": "none",
+        "authData": auth_data,
+        "attStmt": {},
+    }
+    return attestation_object, credential_id, private_key, cose_key
+
+def test_verify_registration_success(passkeys_core, mock_session_challenge):
+    """
+    Tests a successful registration verification.
+    """
+    client_data = {
+        "type": "webauthn.create",
+        "challenge": mock_session_challenge["challenge"],
+        "origin": f"https://{settings.WEBAUTHN_RP_ID}",
+    }
+    attestation_object, credential_id, _, _ = _create_mock_attestation_object()
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(json.dumps(client_data).encode()),
+            "attestationObject": encryption_utils.base64url_encode(cbor2.dumps(attestation_object)),
+        }
+    }
+    result = passkeys_core.verify_registration(response, mock_session_challenge)
+    assert result["credential_id"] == credential_id
+
+def test_verify_registration_rp_id_hash_mismatch(passkeys_core, mock_session_challenge):
+    """
+    Tests that registration verification fails if the RP ID hash does not match.
+    """
+    client_data = {
+        "type": "webauthn.create",
+        "challenge": mock_session_challenge["challenge"],
+        "origin": f"https://{settings.WEBAUTHN_RP_ID}",
+    }
+    attestation_object, _, _, _ = _create_mock_attestation_object(correct_rp_id=False)
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(json.dumps(client_data).encode()),
+            "attestationObject": encryption_utils.base64url_encode(cbor2.dumps(attestation_object)),
+        }
+    }
+    with pytest.raises(ValueError, match="RP ID hash mismatch"):
+        passkeys_core.verify_registration(response, mock_session_challenge)
+
+def test_verify_registration_user_present_flag_not_set(passkeys_core, mock_session_challenge):
+    """
+    Tests that registration verification fails if the user present flag is not set.
+    """
+    client_data = {
+        "type": "webauthn.create",
+        "challenge": mock_session_challenge["challenge"],
+        "origin": f"https://{settings.WEBAUTHN_RP_ID}",
+    }
+    attestation_object, _, _, _ = _create_mock_attestation_object(correct_flags=False)
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(json.dumps(client_data).encode()),
+            "attestationObject": encryption_utils.base64url_encode(cbor2.dumps(attestation_object)),
+        }
+    }
+    with pytest.raises(ValueError, match="User Present flag not set"):
+        passkeys_core.verify_registration(response, mock_session_challenge)
+
+def test_verify_authentication_expired_challenge(passkeys_core, mock_session_challenge, monkeypatch):
+    """
+    Tests that authentication verification fails if the challenge has expired.
+    """
+    monkeypatch.setattr(time, "time", lambda: mock_session_challenge["timestamp"] + 300)
+    with pytest.raises(ValueError, match="Challenge expired"):
+        passkeys_core.verify_authentication({}, mock_session_challenge, MagicMock())
+
+def test_verify_authentication_challenge_mismatch(passkeys_core, mock_session_challenge):
+    """
+    Tests that authentication verification fails if the client data challenge does not match.
+    """
+    client_data = {
+        "type": "webauthn.get",
+        "challenge": encryption_utils.base64url_encode(b"wrong_challenge"),
+        "origin": f"https://{settings.WEBAUTHN_RP_ID}",
+    }
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(json.dumps(client_data).encode()),
+        }
+    }
+    with pytest.raises(ValueError, match="Challenge mismatch"):
+        passkeys_core.verify_authentication(response, mock_session_challenge, MagicMock())
+
+def test_verify_authentication_invalid_origin(passkeys_core, mock_session_challenge):
+    """
+    Tests that authentication verification fails if the origin does not match the RP ID.
+    """
+    client_data = {
+        "type": "webauthn.get",
+        "challenge": mock_session_challenge["challenge"],
+        "origin": "https://evil.com",
+    }
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(json.dumps(client_data).encode()),
+        }
+    }
+    with pytest.raises(ValueError, match="not valid for RP ID"):
+        passkeys_core.verify_authentication(response, mock_session_challenge, MagicMock())
+
+def test_verify_authentication_success_ec(passkeys_core, mock_session_challenge):
+    """
+    Tests a successful authentication verification with an EC key.
+    """
+    _, _, private_key, cose_key = _create_mock_attestation_object(key_type='ec')
+    mock_credential = MagicMock()
+    mock_credential.public_key = cbor2.dumps(cose_key)
+    mock_credential.sign_count = 0
+
+    client_data = {
+        "type": "webauthn.get",
+        "challenge": mock_session_challenge["challenge"],
+        "origin": f"https://{settings.WEBAUTHN_RP_ID}",
+    }
+    client_data_json_bytes = json.dumps(client_data).encode()
+
+    rp_id_hash = hashlib.sha256(settings.WEBAUTHN_RP_ID.encode("utf-8")).digest()
+    flags = 0b00000101  # User Present and User Verified
+    sign_count = 1
+    auth_data = (
+        rp_id_hash +
+        flags.to_bytes(1, 'big') +
+        sign_count.to_bytes(4, 'big')
+    )
+
+    signed_data = auth_data + hashlib.sha256(client_data_json_bytes).digest()
+    signature = private_key.sign(signed_data, ec.ECDSA(hashes.SHA256()))
+
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(client_data_json_bytes),
+            "authenticatorData": encryption_utils.base64url_encode(auth_data),
+            "signature": encryption_utils.base64url_encode(signature),
+        }
+    }
+    new_sign_count = passkeys_core.verify_authentication(response, mock_session_challenge, mock_credential)
+    assert new_sign_count == sign_count
+
+def test_verify_authentication_success_rsa(passkeys_core, mock_session_challenge):
+    """
+    Tests a successful authentication verification with an RSA key.
+    """
+    _, _, private_key, cose_key = _create_mock_attestation_object(key_type='rsa')
+    mock_credential = MagicMock()
+    mock_credential.public_key = cbor2.dumps(cose_key)
+    mock_credential.sign_count = 0
+
+    client_data = {
+        "type": "webauthn.get",
+        "challenge": mock_session_challenge["challenge"],
+        "origin": f"https://{settings.WEBAUTHN_RP_ID}",
+    }
+    client_data_json_bytes = json.dumps(client_data).encode()
+
+    rp_id_hash = hashlib.sha256(settings.WEBAUTHN_RP_ID.encode("utf-8")).digest()
+    flags = 0b00000101
+    sign_count = 1
+    auth_data = (
+        rp_id_hash +
+        flags.to_bytes(1, 'big') +
+        sign_count.to_bytes(4, 'big')
+    )
+
+    signed_data = auth_data + hashlib.sha256(client_data_json_bytes).digest()
+    signature = private_key.sign(
+        signed_data,
+        padding.PKCS1v15(),
+        hashes.SHA256()
+    )
+
+    response = {
+        "response": {
+            "clientDataJSON": encryption_utils.base64url_encode(client_data_json_bytes),
+            "authenticatorData": encryption_utils.base64url_encode(auth_data),
+            "signature": encryption_utils.base64url_encode(signature),
+        }
+    }
+    new_sign_count = passkeys_core.verify_authentication(response, mock_session_challenge, mock_credential)
+    assert new_sign_count == sign_count


### PR DESCRIPTION
Adds a significant number of new tests to the project, primarily focused on the `authtuna/core/passkeys` and `authtuna/manager/asynchronous` modules. This addresses the user's request to increase the test coverage to at least 85%.

The new tests cover:
- Passkey registration and authentication, including various cryptographic algorithms and failure scenarios.
- Core user management functions such as creation, deletion, and password changes.
- Authentication and authorization logic in the `AuthTunaAsync` facade.

All new and existing tests are passing.